### PR TITLE
Fix React warning in Kanban droppable components

### DIFF
--- a/client/src/components/Kanban/KanbanBoard.js
+++ b/client/src/components/Kanban/KanbanBoard.js
@@ -21,7 +21,7 @@ import {
   Avatar
 } from '@mui/material';
 import { MoreVert, Phone, Email, Edit, Visibility, TrendingUp, Refresh, Schedule } from '@mui/icons-material';
-import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd';
+import { DragDropContext, Droppable, Draggable } from '../../utils/safeDnd';
 import { useNavigate } from 'react-router-dom';
 import axiosConfig from '../../config/axios';
 

--- a/client/src/utils/safeDnd.js
+++ b/client/src/utils/safeDnd.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import {
+  DragDropContext,
+  Droppable as RawDroppable,
+  Draggable as RawDraggable
+} from 'react-beautiful-dnd';
+
+const droppableDefaults = RawDroppable?.defaultProps
+  ? { ...RawDroppable.defaultProps }
+  : {};
+const draggableDefaults = RawDraggable?.defaultProps
+  ? { ...RawDraggable.defaultProps }
+  : {};
+
+if (RawDroppable && Object.prototype.hasOwnProperty.call(RawDroppable, 'defaultProps')) {
+  delete RawDroppable.defaultProps;
+}
+
+if (RawDraggable && Object.prototype.hasOwnProperty.call(RawDraggable, 'defaultProps')) {
+  delete RawDraggable.defaultProps;
+}
+
+const Droppable = (props) => {
+  const mergedProps = { ...droppableDefaults, ...props };
+  return <RawDroppable {...mergedProps} />;
+};
+
+Droppable.displayName = RawDroppable?.displayName ?? 'Droppable';
+
+const Draggable = (props) => {
+  const mergedProps = { ...draggableDefaults, ...props };
+  return <RawDraggable {...mergedProps} />;
+};
+
+Draggable.displayName = RawDraggable?.displayName ?? 'Draggable';
+
+export { DragDropContext, Droppable, Draggable };


### PR DESCRIPTION
## Summary
- add a safe drag and drop helper that removes defaultProps from the memoized react-beautiful-dnd exports while reapplying their defaults manually
- update the Kanban board to consume the helper so the React warning about memoized defaultProps no longer appears

## Testing
- npm --prefix client run build *(fails to complete in the container and was cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_68e4016a2ee48320bd6054739a64b583