### PR TITLE
Allow Reagendamiento note category

### DIFF
--- a/server/models/Prospecto.js
+++ b/server/models/Prospecto.js
@@ -77,7 +77,7 @@ const prospectoSchema = new mongoose.Schema({
     },
     categoria: {
       type: String,
-      enum: ['General', 'Puntualidad', 'Calidad', 'Cliente'],
+      enum: ['General', 'Puntualidad', 'Calidad', 'Cliente', 'Reagendamiento'],
       default: 'General'
     }
   }],


### PR DESCRIPTION
## Summary
- allow prospect notes to use the "Reagendamiento" category by updating the schema enum

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e40abf3b6c83209007d6d3f1252af4