### PR TITLE
Display reagendamiento evidence in supervision comments

### DIFF
--- a/client/src/components/Prospectos/ProspectoDetalle.js
+++ b/client/src/components/Prospectos/ProspectoDetalle.js
@@ -83,7 +83,7 @@ const prioridadColors = {
   urgente: 'error'
 };
 
-const comentarioCategorias = ['General', 'Puntualidad', 'Calidad', 'Cliente'];
+const comentarioCategorias = ['General', 'Puntualidad', 'Calidad', 'Cliente', 'Reagendamiento'];
 
 const tipoProductoLabels = {
   ventana: 'Ventana',
@@ -373,18 +373,31 @@ const ProspectoDetalle = () => {
         formData.append(`evidencias`, archivo);
       });
       
-      await axiosConfig.put(`/prospectos/${id}`, formData, {
+      const evidenciasPrevias = prospecto?.evidenciasReagendamiento || [];
+
+      const { data: updateResponse } = await axiosConfig.put(`/prospectos/${id}`, formData, {
         headers: {
           'Content-Type': 'multipart/form-data'
         }
       });
-      
+
+      const updatedProspecto = updateResponse?.prospecto || null;
+      if (updatedProspecto) {
+        setProspecto(updatedProspecto);
+      }
+
+      const evidenciasActuales = updatedProspecto?.evidenciasReagendamiento || [];
+      const nuevasEvidencias = evidenciasActuales.filter((archivo) =>
+        !evidenciasPrevias.some((prev) => prev.url === archivo.url)
+      );
+
       // Agregar comentario con el motivo del reagendamiento
       await axiosConfig.post(`/prospectos/${id}/comentarios`, {
         contenido: `📅 Cita reagendada - Motivo: ${motivoReagendamiento}`,
-        categoria: 'Reagendamiento'
+        categoria: 'Reagendamiento',
+        archivos: nuevasEvidencias
       });
-      
+
       // Limpiar formulario
       setMotivoReagendamiento('');
       setEvidenciasReagendamiento([]);
@@ -907,6 +920,60 @@ const ProspectoDetalle = () => {
                             </Typography>
                             {nota.categoria && (
                               <Chip label={nota.categoria} size="small" sx={{ mt: 0.5 }} />
+                            )}
+                            {Array.isArray(nota.archivos) && nota.archivos.length > 0 && (
+                              <Box sx={{ mt: 1 }}>
+                                <Typography
+                                  variant="caption"
+                                  color="text.secondary"
+                                  sx={{ display: 'block', fontWeight: 600, textTransform: 'uppercase', mb: 0.5 }}
+                                >
+                                  Evidencias
+                                </Typography>
+                                <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
+                                  {nota.archivos.map((archivo, archivoIndex) => {
+                                    const key = archivo.url || `${nota._id || index}-archivo-${archivoIndex}`;
+                                    const esImagen = archivo.tipo?.startsWith('image/');
+
+                                    if (esImagen) {
+                                      return (
+                                        <Box
+                                          key={key}
+                                          sx={{
+                                            width: 100,
+                                            height: 72,
+                                            borderRadius: 1,
+                                            overflow: 'hidden',
+                                            border: '1px solid',
+                                            borderColor: 'divider',
+                                            cursor: 'pointer',
+                                            '&:hover': { boxShadow: 3 }
+                                          }}
+                                          onClick={() => window.open(archivo.url, '_blank', 'noopener,noreferrer')}
+                                        >
+                                          <img
+                                            src={archivo.url}
+                                            alt={archivo.nombre || `Evidencia ${archivoIndex + 1}`}
+                                            style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+                                          />
+                                        </Box>
+                                      );
+                                    }
+
+                                    return (
+                                      <Button
+                                        key={key}
+                                        size="small"
+                                        variant="outlined"
+                                        startIcon={<AttachFile fontSize="small" />}
+                                        onClick={() => window.open(archivo.url, '_blank', 'noopener,noreferrer')}
+                                      >
+                                        {archivo.nombre || `Archivo ${archivoIndex + 1}`}
+                                      </Button>
+                                    );
+                                  })}
+                                </Box>
+                              </Box>
                             )}
                           </>
                         }

--- a/server/models/Prospecto.js
+++ b/server/models/Prospecto.js
@@ -77,9 +77,15 @@ const prospectoSchema = new mongoose.Schema({
     },
     categoria: {
       type: String,
-      enum: ['General', 'Puntualidad', 'Calidad', 'Cliente'],
+      enum: ['General', 'Puntualidad', 'Calidad', 'Cliente', 'Reagendamiento'],
       default: 'General'
-    }
+    },
+    archivos: [{
+      nombre: String,
+      url: String,
+      tipo: String,
+      fechaSubida: Date
+    }]
   }],
   
   // Timeline de instalación / etapas

--- a/server/routes/prospectos.js
+++ b/server/routes/prospectos.js
@@ -166,18 +166,36 @@ router.get('/:id/comentarios', auth, verificarPermiso('prospectos', 'leer'), asy
 // Agregar comentario
 router.post('/:id/comentarios', auth, verificarPermiso('prospectos', 'actualizar'), async (req, res) => {
   try {
-    const { contenido, categoria } = req.body;
+    const { contenido, categoria, archivos } = req.body;
 
     const prospecto = await Prospecto.findById(req.params.id);
     if (!prospecto) {
       return res.status(404).json({ message: 'Prospecto no encontrado' });
     }
 
+    let archivosNota = [];
+
+    if (archivos) {
+      if (Array.isArray(archivos)) {
+        archivosNota = archivos;
+      } else if (typeof archivos === 'string') {
+        try {
+          const parsed = JSON.parse(archivos);
+          if (Array.isArray(parsed)) {
+            archivosNota = parsed;
+          }
+        } catch (parseError) {
+          console.warn('No se pudieron parsear los archivos del comentario:', parseError);
+        }
+      }
+    }
+
     prospecto.notas.push({
       usuario: req.usuario._id,
       contenido,
       tipo: 'nota',
-      categoria: categoria || 'General'
+      categoria: categoria || 'General',
+      archivos: archivosNota
     });
 
     prospecto.fechaUltimoContacto = new Date();


### PR DESCRIPTION
## Summary
- allow selecting the Reagendamiento category from the supervision comment dropdown
- persist optional evidence metadata on prospect notes when comments are created
- surface attached evidence alongside supervision comments with inline previews and download links

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e40abf3b6c83209007d6d3f1252af4